### PR TITLE
Spring Wiring Cleanup for Invariant Engine

### DIFF
--- a/Invariant/src/main/java/com/example/Invariant/controller/InvariantController.java
+++ b/Invariant/src/main/java/com/example/Invariant/controller/InvariantController.java
@@ -15,7 +15,12 @@ import java.util.Map;
 @RestController
 public class InvariantController {
 
-    private final SimpleInvariantEvaluator evaluator = new SimpleInvariantEvaluator();
+    private final SimpleInvariantEvaluator evaluator;
+
+    public InvariantController(SimpleInvariantEvaluator evaluator) {
+
+        this.evaluator = evaluator;
+    }
 
     @PostMapping("/invariant/evaluate")
     public List<InvariantResult> evaluate(@RequestBody Map<String, Object> data) {

--- a/Invariant/src/main/java/com/example/Invariant/core/impl/SimpleInvariantEvaluator.java
+++ b/Invariant/src/main/java/com/example/Invariant/core/impl/SimpleInvariantEvaluator.java
@@ -4,10 +4,12 @@ import com.example.Invariant.core.Invariant;
 import com.example.Invariant.core.InvariantContext;
 import com.example.Invariant.core.InvariantEvaluator;
 import com.example.Invariant.core.InvariantResult;
+import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Service
 public class SimpleInvariantEvaluator implements InvariantEvaluator {
 
     @Override
@@ -26,7 +28,7 @@ public class SimpleInvariantEvaluator implements InvariantEvaluator {
 
             Object value = context.getData().get("amount");
 
-            // Case 1: missing key
+
             if (value == null) {
                 result.setSatisfied(false);
                 result.setFailureReason("required key 'amount' missing");
@@ -34,7 +36,7 @@ public class SimpleInvariantEvaluator implements InvariantEvaluator {
                 continue;
             }
 
-            // Case 2: wrong type
+
             if (!(value instanceof Integer)) {
                 result.setSatisfied(false);
                 result.setFailureReason("invalid type for key 'amount'");


### PR DESCRIPTION
## Spring Wiring Cleanup for Invariant Engine

This PR refines the Invariant Engine setup by aligning it with standard Spring dependency injection practices, without changing any core evaluation logic.

---

## What’s Changed

- Registered the invariant evaluator as a Spring-managed bean
- Replaced manual object creation with constructor-based dependency injection
- Preserved existing engine behavior and API contracts
- Improved testability and maintainability of the codebase

---

## Design Notes

- Core invariant logic remains framework-agnostic
- Controller now declares dependencies instead of instantiating them
- No persistence, MongoDB, or infrastructure concerns are introduced

This change focuses purely on wiring correctness and architectural hygiene.

---

## Next Steps

- Add unit tests to lock invariant engine behavior
- Improve invariant rule expressiveness
- Introduce persistence only after behavior is fully tested
